### PR TITLE
Add link to full schedule, following 2018 Summit example

### DIFF
--- a/templates/berlin/schedule.php
+++ b/templates/berlin/schedule.php
@@ -71,3 +71,7 @@
 </div>
 
 <br>
+
+<p>Schedule is subject to change. View the <a href="https://indieweb.org/2019/Berlin/Schedule">full schedule grid</a> on the IndieWeb wiki for the latest updates.</p>
+
+<br>


### PR DESCRIPTION
Schedule hasn’t been added on the wiki yet, but this adds the link to the 2019.indieweb.org landing page.