### PR TITLE
Add h-feed to the summit page and h-card markup for attendees.

### DIFF
--- a/public/summit.php
+++ b/public/summit.php
@@ -139,7 +139,7 @@ include(dirname(__FILE__).'/../lib/rsvps.php');
   </div>
 
 
-  <div class="ui vertical stripe segment" id="rsvps">
+  <div class="ui vertical stripe segment h-feed" id="rsvps">
     <div class="ui text container">
       <h3 class="ui header">Indie RSVPs</h3>
 

--- a/templates/show-rsvps.php
+++ b/templates/show-rsvps.php
@@ -11,12 +11,12 @@ foreach($rsvps as $rsvp):
   if(parse_url($rsvp['source'], PHP_URL_HOST) == 'brid-gy.appspot.com')
     continue;
   ?>
-  <div class="rsvp">
+  <div class="rsvp h-card">
     <div class="profile-photo">
       <?php if($rsvp['author_photo']): ?>
         <?php if($rsvp['data']['author']['url']): ?>
           <a href="<?= $rsvp['data']['author']['url'] ?>">
-            <img src="/img.php?event=<?= $event ?>&img=<?= $rsvp['author_photo'] ?>" width="48" class="photo">
+            <img src="/img.php?event=<?= $event ?>&img=<?= $rsvp['author_photo'] ?>" width="48" height="48" class="photo u-photo">
           </a>
         <?php endif; ?>
       <?php else: ?>
@@ -26,7 +26,7 @@ foreach($rsvps as $rsvp):
     <div class="profile-info">
       <div>
         <?php if($rsvp['data']['author']['url']): ?>
-          <a href="<?= $rsvp['data']['author']['url'] ?>">
+          <a href="<?= $rsvp['data']['author']['url'] ?>" class="p-name u-url">
            <?= $rsvp['data']['author']['name'] ?: '' ?>
           </a>
         <?php endif; ?>

--- a/templates/show-tito-tickets.php
+++ b/templates/show-tito-tickets.php
@@ -19,15 +19,15 @@
           $websites[] = parse_url($ticket->website, PHP_URL_HOST);
         }
       ?>
-      <div class="rsvp">
+      <div class="rsvp h-card">
         <div class="profile-photo">
           <? if($ticket->website): ?><a href="<?= $ticket->website ?>"><? endif; ?>
-            <img src="<?= gravatar($ticket->email) ?>" width="48" class="photo">
+            <img src="<?= gravatar($ticket->email) ?>" width="48" height="48" class="photo u-photo">
           <? if($ticket->website): ?></a><? endif; ?>
         </div>
         <div class="profile-info">
           <div>
-            <? if($ticket->website): ?><a href="<?= $ticket->website ?>"><? endif; ?>
+            <? if($ticket->website): ?><a href="<?= $ticket->website ?>" class="p-name u-url"><? endif; ?>
               <?= $ticket->name ?>
             <? if($ticket->website): ?></a><? endif; ?>
           </div>    


### PR DESCRIPTION
Hi @aaronpk I think this should do it but let me know if there are any problems. The h-event on the body of the summit page means readers need to find the h-feed in the children. I also added a height to the images so that they're all the same, which allows the double column to line up properly.